### PR TITLE
chore: rename roomid to room_id to harmonize parameters

### DIFF
--- a/.woodpecker/notify.yml
+++ b/.woodpecker/notify.yml
@@ -15,8 +15,8 @@ steps:
         from_secret: matrix_homeserver
       password:
         from_secret: matrix_password
-      roomid:
-        from_secret: matrix_roomid
+      room_id:
+        from_secret: matrix_room_id
       username:
         from_secret: matrix_username
     when:

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -26,7 +26,7 @@ steps:
   image: quay.io/thegeeklab/matrix
   settings:
     homeserver: https://matrix.org
-    roomid: randomstring:matrix.org
+    room_id: randomstring:matrix.org
     username: octocat
     password: random-secret
 ```
@@ -57,7 +57,7 @@ docker build --file Containerfile.multiarch --tag thegeeklab/wp-matrix .
 
 ```Shell
 docker run --rm \
-  -e PLUGIN_ROOMID=randomstring:matrix.org \
+  -e PLUGIN_ROOM_ID=randomstring:matrix.org \
   -e PLUGIN_USERNAME=octocat \
   -e PLUGIN_PASSWORD=random-secret \
   -v $(pwd):/build:z \

--- a/docs/data/data.yaml
+++ b/docs/data/data.yaml
@@ -33,9 +33,9 @@ properties:
     type: string
     required: false
 
-  - name: roomid
+  - name: room_id
     description: |
-      Roomid to send messages to.
+      Room ID to send messages to.
     type: string
     required: false
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -110,9 +110,9 @@ func Flags(settings *Settings, category string) []cli.Flag {
 			Category:    category,
 		},
 		&cli.StringFlag{
-			Name:        "roomid",
-			EnvVars:     []string{"PLUGIN_ROOMID", "MATRIX_ROOMID"},
-			Usage:       "roomid to send messages to",
+			Name:        "room_id",
+			EnvVars:     []string{"PLUGIN_ROOM_ID", "PLUGIN_ROOMID", "MATRIX_ROOMID", "MATRIX_ROOM_ID"},
+			Usage:       "room id to send messages to",
 			Destination: &settings.RoomID,
 			Category:    category,
 		},


### PR DESCRIPTION
BREAKING CHANGE: The `roomid` parameter has been renamed to `room_id`. For most users, this change should not be breaking, as the `roomid` Woodpecker Plugin __parameter__ should continue to work as a fallback. In the case of CLI flags, however, there is no fallback.